### PR TITLE
Implement blowing slot boundary condition for arbitarary continuous x locations

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -114,6 +114,7 @@ class Physics():
 class JetMethod(Enum):
     none = "None"
     constant = "Constant"
+    sinusoidal = "Sinusoidal"
     adaptive = "Adaptive"
 
 class Jet():

--- a/python/jet_actuator.py
+++ b/python/jet_actuator.py
@@ -1,0 +1,82 @@
+import numpy as np
+from config import Config
+import libstreams as streams
+
+# the equation of the polynomial for the jet actuation in coordinates local to the jet
+# actuator. This means that the jet actuator starts at x = 0 and ends at x = slot_end
+# 
+# this must be recomputed at every amplitude change
+class Polynomial():
+    def __init__(self, a: float, b: float, c: float):
+        self.a = a
+        self.b = b
+        self.c = c
+
+    def evaluate(self, x_idx: int) -> float:
+        return self.a * x_idx**2  + \
+                self.b * x_idx + \
+                self.c
+
+# helper class to recompute the polynomial of the jet actuator
+class PolynomialFactory():
+    def __init__(self, vertex_x: float, slot_start: float, slot_end: float):
+        self.slot_start = slot_start
+        self.slot_end = slot_end
+        self.vertex_x  = vertex_x
+
+    def poly(self, amplitude: float) -> Polynomial:
+        a = amplitude/(self.vertex_x**2 - self.vertex_x*self.slot_end- (self.vertex_x - self.slot_end)*self.slot_start)
+        b = -(amplitude*self.slot_end+ amplitude*self.slot_start)/(self.vertex_x**2 - self.vertex_x*self.slot_end- (self.vertex_x - self.slot_end)*self.slot_start)
+        c = amplitude*self.slot_end*self.slot_start/(self.vertex_x**2 - self.vertex_x*self.slot_end- (self.vertex_x - self.slot_end)*self.slot_start)
+
+        return Polynomial(a, b, c)
+
+class JetActuator():
+    def __init__(self, rank: int, config: Config):
+        # if x_start_slot == -1 then we do not have a matrix
+        # allocated on this MPI process
+
+        self.rank = rank
+        self.config = config
+
+        vertex_x = (config.jet.slot_start +  config.jet.slot_end) / 2
+        self.factory = PolynomialFactory(vertex_x, config.jet.slot_start, config.jet.slot_end)
+
+        self.local_slot_start_x = streams.mod_streams.x_start_slot
+        self.local_slot_nx = streams.mod_streams.nx_slot
+        self.local_slot_nz = streams.mod_streams.nz_slot
+
+        self.has_slot = streams.mod_streams.x_start_slot != -1
+
+        if self.has_slot:
+            print(self.local_slot_nx, self.local_slot_nz, self.local_slot_start_x)
+            self.bc_velocity = streams.mod_streams.blowing_bc_slot_velocity[:, :]
+
+    def set_amplitude(self, amplitude: float):
+        # WARNING: copying to GPU and copying to CPU must happen on ALL mpi procs
+        # if we have a matrix, we can adjust the velocity of the blowing actuator
+        streams.wrap_copy_blowing_bc_to_cpu()
+
+        if not self.has_slot:
+            streams.wrap_copy_blowing_bc_to_gpu()
+            return None
+
+        # calculate the equation of the polynomial that the velocity of the jet
+        # actuator will have with this amplitude
+        poly = self.factory.poly(amplitude)
+
+        for idx in range(self.local_slot_nx):
+            local_x = self.local_slot_start_x + idx
+            global_x = self.config.local_to_global_x(local_x, self.rank)
+
+            velo =  poly.evaluate(global_x)
+            print(f"velocity at idx {idx} / local x {local_x} / global x {global_x} ::: {velo}")
+
+            self.bc_velocity[idx, 0:self.local_slot_nz] = velo
+
+        print(f"array shape for BC", self.bc_velocity.shape)
+
+        # finally, copy everything back to the GPU
+        streams.wrap_copy_blowing_bc_to_gpu()
+        return None
+

--- a/python/jet_actuator.py
+++ b/python/jet_actuator.py
@@ -29,6 +29,14 @@ class PolynomialFactory():
         self.vertex_x  = vertex_x
 
     def poly(self, amplitude: float) -> Polynomial:
+        # see streams section of lab documentation for the derivation of this
+        #
+        # in essence, it is solving for the coefficients a,b,c of the polynomial
+        # y = ax^2 + bx +c 
+        # using the fact that
+        # y(jet start) = 0
+        # y(jet end) = 0
+        # y((jet start + jet_end) / 2) = amplitude
         a = amplitude/(self.vertex_x**2 - self.vertex_x*self.slot_end- (self.vertex_x - self.slot_end)*self.slot_start)
         b = -(amplitude*self.slot_end+ amplitude*self.slot_start)/(self.vertex_x**2 - self.vertex_x*self.slot_end- (self.vertex_x - self.slot_end)*self.slot_start)
         c = amplitude*self.slot_end*self.slot_start/(self.vertex_x**2 - self.vertex_x*self.slot_end- (self.vertex_x - self.slot_end)*self.slot_start)

--- a/python/jet_actuator.py
+++ b/python/jet_actuator.py
@@ -49,7 +49,7 @@ class JetActuator():
         self.has_slot = streams.mod_streams.x_start_slot != -1
 
         if self.has_slot:
-            print(self.local_slot_nx, self.local_slot_nz, self.local_slot_start_x)
+            #print(self.local_slot_nx, self.local_slot_nz, self.local_slot_start_x)
             self.bc_velocity = streams.mod_streams.blowing_bc_slot_velocity[:, :]
 
     def set_amplitude(self, amplitude: float):
@@ -70,11 +70,11 @@ class JetActuator():
             global_x = self.config.local_to_global_x(local_x, self.rank)
 
             velo =  poly.evaluate(global_x)
-            print(f"velocity at idx {idx} / local x {local_x} / global x {global_x} ::: {velo}")
+            #print(f"velocity at idx {idx} / local x {local_x} / global x {global_x} ::: {velo}")
 
             self.bc_velocity[idx, 0:self.local_slot_nz] = velo
 
-        print(f"array shape for BC", self.bc_velocity.shape)
+        #print(f"array shape for BC", self.bc_velocity.shape)
 
         # finally, copy everything back to the GPU
         streams.wrap_copy_blowing_bc_to_gpu()

--- a/python/main.py
+++ b/python/main.py
@@ -92,6 +92,9 @@ for i in range(config.temporal.num_iter):
     time += streams.mod_streams.dtglobal
     time_array[:] = time
 
+    streams.wrap_dissipation_calculation()
+    utils.hprint(f"dissipation rate is {streams.mod_streams.dissipation_rate}")
+
     if (i % config.temporal.span_average_io_steps) == 0:
         utils.hprint("writing span average to output")
         streams.wrap_copy_gpu_to_cpu()

--- a/python/main.py
+++ b/python/main.py
@@ -45,6 +45,7 @@ temp_field = np.zeros((config.nx_mpi(), config.ny_mpi(), config.nz_mpi()), dtype
 dt_array = np.zeros(1)
 time_array = np.zeros(1)
 dissipation_rate_array = np.zeros(1)
+energy_array = np.zeros(1)
 
 #
 # execute streams setup routines
@@ -79,6 +80,7 @@ span_average_dset = io_utils.VectorFieldXY2D(span_averages, [5, *span_average_sh
 shear_stress_dset = io_utils.ScalarFieldX1D(span_averages, [config.grid.nx], numwrites, "shear_stress", rank)
 span_average_time_dset = io_utils.Scalar1D(span_averages, [1], numwrites, "time", rank)
 dissipation_rate_dset = io_utils.Scalar1D(span_averages, [1], numwrites, "dissipation_rate", rank)
+energy_dset = io_utils.Scalar1D(span_averages, [1], numwrites, "energy", rank)
 
 # trajectories files
 dt_dset = io_utils.Scalar1D(trajectories, [1], config.temporal.num_iter, "dt", rank)
@@ -113,6 +115,11 @@ for i in range(config.temporal.num_iter):
         streams.wrap_dissipation_calculation()
         dissipation_rate_array[:] = streams.mod_streams.dissipation_rate
         dissipation_rate_dset.write_array(dissipation_rate_array)
+
+        # calculate energy on GPU and store the result
+        streams.wrap_energy_calculation()
+        energy_array[:] = streams.mod_streams.energy
+        energy_dset.write_array(energy_array)
 
     # save dt information for every step
     dt_array[:] = streams.mod_streams.dtglobal

--- a/python/main.py
+++ b/python/main.py
@@ -78,6 +78,8 @@ flowfield_time_dset = io_utils.Scalar1D(flowfields, [1], flowfield_writes, "time
 
 # span average files
 numwrites = int(math.ceil(config.temporal.num_iter / config.temporal.span_average_io_steps))
+
+# this is rho, u, v, w, E (already normalized from the rho u, rho v... values from streams)
 span_average_dset = io_utils.VectorFieldXY2D(span_averages, [5, *span_average_shape], numwrites, "span_average", rank)
 shear_stress_dset = io_utils.ScalarFieldX1D(span_averages, [config.grid.nx], numwrites, "shear_stress", rank)
 span_average_time_dset = io_utils.Scalar0D(span_averages, [1], numwrites, "time", rank)
@@ -104,12 +106,12 @@ z_mesh_dset.write_array(z_mesh)
 # Main solver loop, we start time stepping until we are done
 #
 
-actuator = jet_actuator.JetActuator(rank, config)
+actuator = jet_actuator.init_actuator(rank, config)
 
 time = 0
 for i in range(config.temporal.num_iter):
 
-    actuator.set_amplitude(1.0)
+    actuator.step_actuator()
 
     streams.wrap_step_solver()
 

--- a/python/main.py
+++ b/python/main.py
@@ -44,6 +44,7 @@ with open("/input/input.json", "r") as f:
 span_average = np.zeros([5, config.nx_mpi(), config.ny_mpi()], dtype=np.float64)
 temp_field = np.zeros((config.nx_mpi(), config.ny_mpi(), config.nz_mpi()), dtype=np.float64)
 dt_array = np.zeros(1)
+amplitude_array = np.zeros(1)
 time_array = np.zeros(1)
 dissipation_rate_array = np.zeros(1)
 energy_array = np.zeros(1)
@@ -88,6 +89,7 @@ energy_dset = io_utils.Scalar0D(span_averages, [1], numwrites, "energy", rank)
 
 # trajectories files
 dt_dset = io_utils.Scalar0D(trajectories, [1], config.temporal.num_iter, "dt", rank)
+amplitude_dset = io_utils.Scalar0D(trajectories, [1], config.temporal.num_iter, "jet_amplitude", rank)
 
 # mesh datasets
 x_mesh_dset = io_utils.Scalar1DX(mesh_h5, [config.grid.nx], 1, "x_grid", rank)
@@ -111,7 +113,7 @@ actuator = jet_actuator.init_actuator(rank, config)
 time = 0
 for i in range(config.temporal.num_iter):
 
-    actuator.step_actuator()
+    amplitude = actuator.step_actuator(time)
 
     streams.wrap_step_solver()
 
@@ -149,6 +151,10 @@ for i in range(config.temporal.num_iter):
     # save dt information for every step
     dt_array[:] = streams.mod_streams.dtglobal
     dt_dset.write_array(dt_array)
+
+    # save amplitude at every step
+    amplitude_array[:] = amplitude
+    amplitude_dset.write_array(amplitude_array)
 
     if not (config.temporal.full_flowfield_io_steps is None):
         if (i % config.temporal.full_flowfield_io_steps) == 0:

--- a/python/main.py
+++ b/python/main.py
@@ -115,11 +115,14 @@ for i in range(config.temporal.num_iter):
         streams.wrap_dissipation_calculation()
         dissipation_rate_array[:] = streams.mod_streams.dissipation_rate
         dissipation_rate_dset.write_array(dissipation_rate_array)
+        utils.hprint(f"dissipation is {dissipation_rate_array[0]}")
 
         # calculate energy on GPU and store the result
         streams.wrap_energy_calculation()
         energy_array[:] = streams.mod_streams.energy
         energy_dset.write_array(energy_array)
+
+        utils.hprint(f"energy is {energy_array[0]}")
 
     # save dt information for every step
     dt_array[:] = streams.mod_streams.dtglobal

--- a/python/utils.py
+++ b/python/utils.py
@@ -12,9 +12,12 @@ def hprint(*args):
 def calculate_span_averages(config: Config, span_average: np.ndarray, temp_field: np.ndarray, streams_data: np.ndarray):
     # for rhou, rhov, rhow, and rhoE
     for data_idx in [1,2,3,4]:
+        # divide rho * VALUE by rho so we exclusively have VALUE
         temp_field[:] = np.divide(streams_data[data_idx, :, :, :], streams_data[0, :, :, :], out = temp_field[:])
 
+        # sum the VALUE across the z direction
         span_average[data_idx, :, :] = np.sum(temp_field, axis=2, out=span_average[data_idx, :, :])
+        # divide the sum by the number of points in the z direction to compute the average
         span_average[data_idx, :, :] /= config.grid.nz
 
     span_average[0, :, :] = np.sum(streams_data[0, :, :, :], axis=2, out=span_average[0, :, :])

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,7 @@ OBJ_FILES = alloc.o bcdf.o bcextr.o bcfree.o bc.o bcrecyc.o bcrelax.o bcshk.o bc
     setup.o solver.o startmpi.o stats.o step.o target_reystress.o tbforce.o updateghost.o utility.o utyibm.o \
     visflx.o writedf.o writefield.o writefieldvtk.o writegridplot3d.o writerst.o \
     writestatbl.o writestatchann.o writestat.o writestatzbl.o write_wallpressure.o visflx_stag.o \
-	write_probe_data.o bcblow.o
+	write_probe_data.o bcblow.o dissipation.o
 
 PY_API_OBJS = min_api.o
 
@@ -67,7 +67,7 @@ STATIC_FILES = alloc.F90 bcdf.F90 bcextr.F90 bcfree.F90 bc.F90 bcrecyc.F90 bcrel
     setup.F90 solver.F90 startmpi.F90 stats.F90 step.F90 target_reystress.F90 tbforce.F90 updateghost.F90 utility.F90 utyibm.F90 \
     visflx.F90 writedf.F90 writefield.F90 writefieldvtk.F90 writegridplot3d.F90 writerst.F90 \
     writestatbl.F90 writestatchann.F90 writestat.F90 writestatzbl.F90 write_wallpressure.F90 visflx_stag.F90 \
-	write_probe_data.F90 bcblow.F90 
+	write_probe_data.F90 bcblow.F90 dissipation.F90
 
 STATIC_MODS = mod_streams.F90 mod_sys.F90 euler.F90
 

--- a/src/alloc.F90
+++ b/src/alloc.F90
@@ -214,7 +214,8 @@ subroutine allocate_vars()
  allocate(wrecyc_gpu(ng,ny,nz,nv))
  allocate(wrecycav_gpu(ng,ny,nv))
 
- allocate(tauw_x(1:nx))
+allocate(tauw_x(1:nx))
+
 !
 endsubroutine allocate_vars
 

--- a/src/alloc.F90
+++ b/src/alloc.F90
@@ -215,6 +215,11 @@ subroutine allocate_vars()
  allocate(wrecycav_gpu(ng,ny,nv))
 
  allocate(tauw_x(1:nx))
+
+ allocate(fdm_y_stencil_gpu(5, ny))
+ allocate(fdm_y_stencil(5, ny))
+ allocate(fdm_individual_stencil(0:1, 0:4, 0:4))
+ allocate(fdm_grid_points(0:4))
 !
 endsubroutine allocate_vars
 

--- a/src/bcblow.F90
+++ b/src/bcblow.F90
@@ -70,7 +70,7 @@ subroutine bcblow(ilat)
 
                         w_gpu(i,1-l,k,1) =  rho
                         w_gpu(i,1-l,k,2) = -rho*uu
-                        w_gpu(i,1-l,k,3) = -rho*(2.*jet_velocity  - vv)
+                        w_gpu(i,1-l,k,3) = rho*(2.*jet_velocity  - vv)
                         w_gpu(i,1-l,k,4) = -rho*ww
                         w_gpu(i,1-l,k,5) = pp*gm+qq*rho
                     enddo

--- a/src/bcblow.F90
+++ b/src/bcblow.F90
@@ -1,41 +1,194 @@
-
+! blowing boundary condition
+!
+! this may ONLY be called if we are on the bottom surface
+! ilat == 3
+! and have properly allocated the correct variables (blowing_bc_slot_velocity, blowing_bc_slot_velocity_gpu) in alloc.f90
 subroutine bcblow(ilat)
     use mod_streams
     implicit none
 
-    integer :: ilat, start_x
+    integer :: ilat
     integer :: i,j,k
     real(mykind) :: jet_velocity, rho
 
     j = 1
-    jet_velocity = 1.0
 
     ! if on the bottom
     if (ilat == 3) then
-        call bcwall_pl(ilat)
+        ! call the the base boundary condition for the bottom wall first.
+        ! I believe we dont use bcwall_pl here since it is categorized under
+        ! the unsteady conditions. 
+        ! Numerically, im not sure if that is the correct decision, so it
+        ! may be something to better investigate in the future
+        call bcwall(ilat)
 
-        ! TODO: make this selection more dynamic
-        if (nrank == 0) then
-            start_x = nx / 2
+        ! check if we should even worry about writing slot velocity information
+        if (x_start_slot /= -1) then
+            !write(*,*) "calling bcblow on bottom wall"
+
             ! w_gpu(:, :, :, 1) -> rho
             ! w_gpu(:, :, :, 2) -> rho u
             ! w_gpu(:, :, :, 3) -> rho v
             ! w_gpu(:, :, :, 4) -> rho w
             ! w_gpu(:, :, :, 5) -> rho E
 
+            ! this -1 in the i indexing is counteracted by by the +1 on the 
+            ! jet_velocity indexing, and this allows us to not
+            ! use custom indexing on the array which makes interoperability with
+            ! numpy easier
+
             !$cuf kernel do(2) <<<*,*>>>
-            do i = start_x,nx
+            do i = x_start_slot,x_start_slot+nx_slot-1
                 do k = 1,nz
-                    ! do stuff here
+#ifdef USE_CUDA
+                    ! we have to shift around the indexing of the blowing BC 
+                    ! array since `i` is indexing based on the entire local domain
+                    ! but blowing_bc_slot_velocity is allocated with reference to only 
+                    ! the size of the slot
+                    jet_velocity = blowing_bc_slot_velocity_gpu(i-x_start_slot+1,k)
+
+
+                    ! w() is indexed differently on CPU and GPU
                     rho = w_gpu(i,j,k,1)
                     w_gpu(i,j,k,3) = rho * jet_velocity
+#else
+                    jet_velocity = blowing_bc_slot_velocity(i-x_start_slot+1,k)
+
+                    ! w() is indexed differently on CPU and GPU
+                    rho = w(1,i,j,k)
+                    w(3, i,j,k) = rho * jet_velocity
+#endif
                 enddo
             enddo
             !@cuf iercuda=cudaDeviceSynchronize()
         endif
-    else 
+    else
         ! TODO: error - we should not be here
     endif
 
-
 end subroutine bcblow
+
+! given parameters from the input file
+! slot_start_x_global
+! slot_end_x_global
+!
+! we calculate LOCALLY:
+! nx_slot (the length of the slot as it pertains to OUR mpi node, used for array allocations)
+! nz_slot = nz, the width of the slot into the channel
+! x_start_slot (the LOCAL location on this MPI node where the blowing boundary condition should be applied)
+subroutine local_slot_locations()
+    use mod_streams, only: slot_start_x_global, slot_end_x_global,  nx_slot, &
+        nz_slot, x_start_slot, nrank, nz, masterproc, nx, force_sbli_blowing_bc 
+
+    implicit none
+
+    integer :: mpi_xstart, mpi_xend
+    integer :: true_slot_start, slot_length, slot_end_local, nxmax
+
+    if (masterproc) then
+        write(*, *) "slot start and slot end (global) is ", slot_start_x_global, slot_end_x_global
+    endif
+
+    ! the STARTING location in a global reference frame of what grid we are 
+    ! responsible for on this MPI node
+    mpi_xstart = nx * nrank
+
+    ! the ENDING location in a global reference frame of what grid we are 
+    ! responsible for on this MPI node
+    mpi_xend = mpi_xstart + nx
+
+    ! for example, with NX = 25 and 4 MPI nodes,
+    ! rank 0 is responsible for 1:25
+    ! rank 1 is responsible for 26:50
+    ! etc...
+    ! but above, mpi_xstart = 0 at rank 0, and mpi_xend = 25. This makes the math
+    ! later on a bit easier but in principle it is the same thing
+
+    ! if we have a blowing boundary condition
+    ! AND
+    ! if the end of the slot is AFTER the global starting place of our grid
+    ! AND
+    ! the start of the slot is BEFORE the global ending point of our grid
+    if ( &
+        (force_sbli_blowing_bc == 1)  .and. &
+        (mpi_xstart <= slot_end_x_global) .and. &
+        (slot_start_x_global <= mpi_xend)) then
+        ! the start of the blowing slot, relative to the start of 
+        ! our grid in a global reference frame. This results in an integer (possibly negative)
+        ! on how far forward or backward from the start of our grid the begining of the slot is
+        true_slot_start = slot_start_x_global - mpi_xstart
+
+        ! the slot start locally is either the first index (1) OR it is some length past the starting
+        ! point of our grid. The start of the slot that we store here CANNOT be negative, because 
+        ! that implies that the slot starts within another grid, and we only care about our grid.
+        x_start_slot = max(1, true_slot_start)
+
+        ! calculate how long the slot is
+        slot_length = slot_end_x_global - slot_start_x_global
+
+        ! then, find out in a global reference frame where the end of the slot is.
+        ! We know that LOCALLY the end of the slot is at a maximum NX (since otherwise it would 
+        ! run into the next grid)
+        slot_end_local = min(nx, true_slot_start + slot_length)
+
+        ! the length of the slot on this local process is just
+        ! the local end of the slot minus the local start of the slot
+        nx_slot = slot_end_local - x_start_slot
+
+        nz_slot = nz
+    else
+        x_start_slot = -1
+        slot_end_local = -1
+        ! these are fairly useless, we wont even allocate an array if 
+        ! x_start_slot = -1
+        nx_slot = 0
+        nz_slot = 0
+    endif
+ 
+    write(*, *) "on nrank ", nrank, "the slot starts at ", x_start_slot, " and ends at ", slot_end_local, &
+        " which is ", nx_slot, " in length, mpi xstart ", mpi_xstart, "mpi xend", mpi_xend, &
+        " force sbli bc is ", force_sbli_blowing_bc
+     
+end subroutine local_slot_locations
+
+! copy
+! CPU -> GPU
+subroutine copy_blowing_bc_to_gpu()
+    use mod_streams
+    if (x_start_slot /= -1) then
+
+#ifdef USE_CUDA
+        blowing_bc_slot_velocity_gpu = blowing_bc_slot_velocity
+#else
+        call move_alloc(blowing_bc_slot_velocity, blowing_bc_slot_velocity_gpu)
+#endif
+
+    endif
+end subroutine
+
+! copy
+! GPU -> CPU
+subroutine copy_blowing_bc_to_cpu()
+    use mod_streams
+
+    if (x_start_slot /= -1) then
+
+#ifdef USE_CUDA
+        blowing_bc_slot_velocity = blowing_bc_slot_velocity_gpu
+#else
+        call move_alloc(blowing_bc_slot_velocity_gpu, blowing_bc_slot_velocity)
+#endif
+
+    endif
+end subroutine
+
+subroutine allocate_blowing_bcs()
+    use mod_streams
+    if (x_start_slot /= -1) then
+        allocate(blowing_bc_slot_velocity(nx_slot, nz_slot))
+
+#ifdef USE_CUDA
+        allocate(blowing_bc_slot_velocity_gpu(nx_slot, nz_slot))
+#endif
+    endif
+end subroutine

--- a/src/bcblow.F90
+++ b/src/bcblow.F90
@@ -133,7 +133,11 @@ subroutine local_slot_locations()
 
         ! the length of the slot on this local process is just
         ! the local end of the slot minus the local start of the slot
-        nx_slot = slot_end_local - x_start_slot
+        ! 
+        ! then, we have to add one to the slot length for 1-based indexing rules:
+        ! if x_start_slot = 1, x_end_slot = 3 then we clearly have 3 locations on the x axis where
+        ! we are forcing, but 3-1 = 2, hence the +1
+        nx_slot = slot_end_local - x_start_slot + 1
 
         nz_slot = nz
     else

--- a/src/dissipation.F90
+++ b/src/dissipation.F90
@@ -123,3 +123,57 @@ subroutine dissipation_calculation()
 
     dissipation_rate = mpi_dissipation_sum
 endsubroutine dissipation_calculation
+
+subroutine energy_calculation()
+    use mod_streams
+
+    implicit none
+
+    integer :: i, j, k
+
+    real*8 :: uu, vv, ww, rho
+    real*8 :: dudx, dvdy, dwdz
+    real*8 :: dx, dy, dz
+    real*8 :: mpi_energy_sum
+
+    ! dissipation_rate is defined in mod_streams, we reset its value here
+    energy = 0.0
+
+    mpi_energy_sum = 0.0
+
+    ! w_gpu(:, :, :, 1) -> rho
+    ! w_gpu(:, :, :, 2) -> rho u
+    ! w_gpu(:, :, :, 3) -> rho v
+    ! w_gpu(:, :, :, 4) -> rho w
+    ! w_gpu(:, :, :, 5) -> rho E
+
+    !$cuf kernel do(3) <<<*,*>>> 
+    do k = 1,nz
+        do j = 1,ny
+            do i = 1,nx
+                rho = w_gpu(i, j, k, 1)
+                uu = w_gpu(i, j, k, 2) / rho
+                vv = w_gpu(i, j, k, 3) / rho
+                ww = w_gpu(i, j, k, 4) / rho
+
+                dx = (x_gpu(i-1) + x_gpu(i+1)) / 2
+                dy = (y_gpu(j-1) + y_gpu(j+1)) / 2
+                dz = (z_gpu(k-1) + z_gpu(k+1)) / 2
+
+                energy = energy + &
+                    (uu**2 + vv**2 + ww**2) * dx * dy * dz
+            enddo
+        enddo
+    enddo
+
+    energy = energy * 0.5
+
+    ! sum all the values across MPI, store the result in mpi_energy_sum 
+    call MPI_REDUCE(energy, mpi_energy_sum, 1, mpi_prec,  MPI_SUM, 0, MPI_COMM_WORLD, iermpi)
+
+    ! distribute mpi_energy_sum to all MPI procs
+    call MPI_BCAST(mpi_energy_sum, 1, mpi_prec, 0, MPI_COMM_WORLD, iermpi)
+
+    energy = mpi_energy_sum
+
+end subroutine energy_calculation

--- a/src/dissipation.F90
+++ b/src/dissipation.F90
@@ -1,0 +1,125 @@
+! calculate the dissipation rate. See lab streams documentation for
+! `Calculated Quantities` for the equation being calculated
+!
+! after calculation, the value is stored in `dissipation_rate` in mod_streams
+subroutine dissipation_calculation()
+    use mod_streams
+
+    implicit none
+
+    integer :: i, j, k
+
+    real*8 :: uu, vv, ww, rho
+    real*8 :: dudx, dvdy, dwdz
+    real*8 :: dx, dy, dz
+    real*8 :: mpi_dissipation_sum
+
+    ! dissipation_rate is defined in mod_streams, we reset its value here
+    dissipation_rate = 0.0
+
+    mpi_dissipation_sum = 0.0
+
+    ! w_gpu(:, :, :, 1) -> rho
+    ! w_gpu(:, :, :, 2) -> rho u
+    ! w_gpu(:, :, :, 3) -> rho v
+    ! w_gpu(:, :, :, 4) -> rho w
+    ! w_gpu(:, :, :, 5) -> rho E
+
+    !$cuf kernel do(3) <<<*,*>>> 
+    do k = 1,nz
+        do j = 1,ny
+            do i = 1,nx
+
+                !
+                ! du/dx
+                !
+                dudx = ( &
+                    ( &
+                        -1 * w_gpu(i+2, j, k, 2) / w_gpu(i+2, j, k, 1) &
+                    ) &
+                    + &
+                    ( &
+                        8 * w_gpu(i+1, j, k, 2) / w_gpu(i+1, j, k, 1) &
+                    ) &
+                    - &
+                    ( &
+                        8 * w_gpu(i-1, j, k, 2) / w_gpu(i-1, j, k, 1) &
+                    ) &
+                    + &
+                    ( &
+                        w_gpu(i-2, j, k, 2) / w_gpu(i-2, j, k, 1) &
+                    ) &
+                ) &
+                ! replace 12 * \Delta x by 6 * (2 \Delta x) since x can vary
+                ! with grid size (Without really looking at grid mesh generation
+                / ( 6 * ( x_gpu(i+1) - x_gpu(i-1)))
+
+                !
+                ! dv/dy
+                !
+                dvdy = ( &
+                    ( &
+                        -1 * w_gpu(i, j+2, k, 3) / w_gpu(i, j+2, k, 1) &
+                    ) &
+                    + &
+                    ( &
+                        8 * w_gpu(i, j+1, k, 3) / w_gpu(i, j+1, k, 1) &
+                    ) &
+                    - &
+                    ( &
+                        8 * w_gpu(i, j-1, k, 3) / w_gpu(i, j-1, k, 1) &
+                    ) &
+                    + &
+                    ( &
+                        w_gpu(i, j-2, k, 3) / w_gpu(i, j-2, k, 1) &
+                    ) &
+                ) &
+                ! replace 12 * \Delta y by 6 * (2 \Delta y) since y can vary
+                ! with grid size (Without really looking at grid mesh generation
+                / ( 6 * ( y_gpu(j+1) - y_gpu(j-1)))
+
+                !
+                ! dw/dz
+                !
+                dwdz = ( &
+                    ( &
+                        -1 * w_gpu(i, j, k+2, 4) / w_gpu(i, j, k+2, 1) &
+                    ) &
+                    + &
+                    ( &
+                        8 * w_gpu(i, j, k+1, 4) / w_gpu(i, j, k+1, 1) &
+                    ) &
+                    - &
+                    ( &
+                        8 * w_gpu(i, j, k-1, 4) / w_gpu(i, j, k-1, 1) &
+                    ) &
+                    + &
+                    ( &
+                        w_gpu(i, j, k-2, 4) / w_gpu(i, j, k-2, 1) &
+                    ) &
+                ) &
+                ! replace 12 * \Delta z by 6 * (2 \Delta z) since z can vary
+                ! with grid size (Without really looking at grid mesh generation
+                / ( 6 * ( z_gpu(k+1) - z_gpu(k-1)))
+
+                dx = (x_gpu(i-1) + x_gpu(i+1)) / 2
+                dy = (y_gpu(j-1) + y_gpu(j+1)) / 2
+                dz = (z_gpu(k-1) + z_gpu(k+1)) / 2
+
+                dissipation_rate = dissipation_rate + &
+                    (dudx**2 + dvdy**2 + dwdz**2) * dx * dy * dz
+            enddo
+        enddo
+    enddo
+    !@cuf iercuda=cudaDeviceSynchronize()
+
+    dissipation_rate = dissipation_rate / (rlx * rly * rlz)
+
+    ! sum all the values across MPI, store the result in mpi_dissipation_sum
+    call MPI_REDUCE(dissipation_rate, mpi_dissipation_sum, 1, mpi_prec,  MPI_SUM, 0, MPI_COMM_WORLD, iermpi)
+
+    ! distribute mpi_dissipation_sum to all MPI procs
+    call MPI_BCAST(mpi_dissipation_sum, 1, mpi_prec, 0, MPI_COMM_WORLD, iermpi)
+
+    dissipation_rate = mpi_dissipation_sum
+endsubroutine dissipation_calculation

--- a/src/dissipation.F90
+++ b/src/dissipation.F90
@@ -76,24 +76,13 @@ subroutine dissipation_calculation()
                 !
                 ! dv/dy
                 !
-                dvdy = ( &
-                    ( &
-                        -1 * w_gpu(i, j+2, k, 3) / w_gpu(i, j+2, k, 1) &
-                    ) &
-                    + &
-                    ( &
-                        8 * w_gpu(i, j+1, k, 3) / w_gpu(i, j+1, k, 1) &
-                    ) &
-                    - &
-                    ( &
-                        8 * w_gpu(i, j-1, k, 3) / w_gpu(i, j-1, k, 1) &
-                    ) &
-                    + &
-                    ( &
-                        w_gpu(i, j-2, k, 3) / w_gpu(i, j-2, k, 1) &
-                    ) &
-                ) &
-                / ( 12 * dy)
+                ! fdm_y_stencil_gpu coeffs are calculated in generate_full_fdm_stencil() subroutine
+                dvdy = &
+                    (w_gpu(i, j, k, 3) / w_gpu(i, j, k, 1)) * fdm_y_stencil_gpu(1, j) + &
+                    (w_gpu(i, j+1, k, 3) / w_gpu(i, j+1, k, 1)) * fdm_y_stencil_gpu(2, j) + &
+                    (w_gpu(i, j-1, k, 3) / w_gpu(i, j-1, k, 1)) * fdm_y_stencil_gpu(3, j) + &
+                    (w_gpu(i, j+2, k, 3) / w_gpu(i, j+2, k, 1)) * fdm_y_stencil_gpu(4, j) + &
+                    (w_gpu(i, j-2, k, 3) / w_gpu(i, j-2, k, 1)) * fdm_y_stencil_gpu(5, j)
 
                 !
                 ! dw/dz
@@ -136,6 +125,140 @@ subroutine dissipation_calculation()
 
     dissipation_rate = mpi_dissipation_sum
 endsubroutine dissipation_calculation
+
+subroutine generate_full_fdm_stencil()
+    use mod_streams, only: delta => fdm_individual_stencil, alpha => fdm_grid_points, &
+        ny, fdm_y_stencil, fdm_y_stencil_gpu, masterproc, y
+
+    implicit none
+
+    integer :: j, i
+    real*8 :: y0, ym1, ym2, yp1, yp2, total
+    total = 0.0
+
+    if (masterproc) write(*,*) "generating FDM stencil for dissipation"
+
+    do j = 1,ny
+        ym2 = y(j-2)
+        ym1 = y(j-1)
+        y0  = y(j)
+        yp1 = y(j+1)
+        yp2 = y(j+2)
+
+        ! j
+        alpha(0) = y0
+        ! j+1
+        alpha(1) = yp1
+        ! j-1
+        alpha(2) = ym1
+        ! j+2
+        alpha(3) = yp2
+        ! j-2
+        alpha(4) = ym2
+
+        ! use alpha to compute the stencil for this set of points
+        call irregular_grid_stencil()
+        fdm_y_stencil(:, j) = delta(1, 4, :)
+
+        do i = 1,5
+            total = total + abs(fdm_y_stencil(i, j))
+        enddo
+    enddo
+
+    write(*,*) "total of stencil coefficients is", total
+
+! copy over to GPU variable
+#ifdef USE_CUDA
+    fdm_y_stencil_gpu = fdm_y_stencil
+#else
+    call move_alloc(fdm_y_stencil, fdm_y_stencil_gpu)
+#endif
+
+endsubroutine
+
+! fetches the grid points from `fdm_grid_points` and operates on `fdm_individual_stencil_gpu` 
+! to perform the algorithm from
+! Generation of Finite Difference Formulas on Arbitrarily Spaced Grids (Fornberg, 1988)
+! to generate a stencil that we can use for the finite difference calculation
+subroutine irregular_grid_stencil()
+    use mod_streams, only: delta => fdm_individual_stencil, alpha => fdm_grid_points
+
+    implicit none
+
+    integer :: M0, N0, v, m, n
+    real*8 :: c1, c2, c3, t1, t2, t3, x0
+
+    M0 = 1
+    N0 = 4
+
+    delta(:, :, :) = 0.0
+    delta(0, 0, 0) = 1.0
+    c1 = 1.0
+
+    x0 = alpha(0)
+
+    do n = 1,N0
+        c2 = 1.0
+
+        do v = 0,n-1
+            c3 = alpha(n) - alpha(v)
+            c2 = c2 * c3
+
+            do m = 0, min(n,M0)
+                t3 = delta(m, n-1, v)
+                t1 = (alpha(n) - x0) * t3
+
+                if (m == 0) then
+                    t2 = 0.0
+                else
+                    t2 = m * delta(m-1, n-1, v)
+                endif
+
+                delta(m, n, v)  = (t1 -t2) / c3
+            enddo
+        enddo
+
+        do m = 0, min(n,M0)
+            if (m == 0) then
+                t1 = 0.0
+            else 
+                t1 = m * delta(m-1, n-1, n-1)
+            endif
+
+            t3 = delta(m, n-1, n-1)
+            t2 = (alpha(n-1) - x0) * t3
+
+            delta(m, n, n) = (c1 / c2) * (t1 - t2)
+        enddo
+
+        c1 = c2
+    enddo
+
+end subroutine
+
+! calculate the first order derivative with 4th order error for a simple grid
+subroutine validate_irregular_fdm()
+    use mod_streams
+
+    fdm_grid_points(0) = 0.0
+    fdm_grid_points(1) = 1.
+    fdm_grid_points(2) = -1.
+    fdm_grid_points(3) = 2.
+    fdm_grid_points(4) = -2.
+
+    call irregular_grid_stencil()
+    ! should output 
+    ! -0.0          (0)
+    ! 0.666667      (2/3)
+    ! -0.666667     (-2/3)
+    ! -0.0833333    (-1/12)
+    ! 0.0833333     (1/12)
+#ifdef USE_CUDA
+#else
+    ! can only print in CPU mode
+    write(*,*) fdm_individual_stencil(1, 4, :)
+#endif
+endsubroutine
 
 subroutine energy_calculation()
     use mod_streams

--- a/src/min_api.F90
+++ b/src/min_api.F90
@@ -90,3 +90,11 @@ subroutine wrap_dissipation_calculation()
 
     call dissipation_calculation()
 end subroutine
+
+! calculate energy. See inner subroutine documentation.
+! after calculation, the value is stored in `energy` in mod_streams
+subroutine wrap_energy_calculation()
+    implicit none
+
+    call energy_calculation()
+end subroutine

--- a/src/min_api.F90
+++ b/src/min_api.F90
@@ -39,6 +39,22 @@ subroutine wrap_copy_cpu_to_gpu()
     call copy_cpu_to_gpu()
 end subroutine
 
+! copy the array for the blowing BC 
+! CPU -> GPU
+!
+! this subroutine must be called on ALL mpi procs
+subroutine wrap_copy_blowing_bc_to_gpu()
+    call copy_blowing_bc_to_gpu()
+end subroutine
+
+! copy the array for the blowing BC 
+! GPU -> CPU
+!
+! this subroutine must be called on ALL mpi procs
+subroutine wrap_copy_blowing_bc_to_cpu()
+    call copy_blowing_bc_to_cpu()
+end subroutine
+
 ! calculate wall shear stress
 ! this subtoutine is a HEAVILY chopped down version of `writestatbl`
 ! in writestatbl.f90

--- a/src/min_api.F90
+++ b/src/min_api.F90
@@ -82,3 +82,11 @@ subroutine wrap_tauw_calculate()
     end if
 !
 end subroutine
+
+! calculate dissipation rate. See inner subroutine documentation.
+! after calculation, the value is stored in `dissipation_rate` in mod_streams
+subroutine wrap_dissipation_calculation()
+    implicit none
+
+    call dissipation_calculation()
+end subroutine

--- a/src/mod_streams.F90
+++ b/src/mod_streams.F90
@@ -87,6 +87,10 @@ module mod_streams
 !f2py real*8 :: dissipation_rate
  real(mykind) :: dissipation_rate
 
+ ! energy is calculated in dissipation.F90, subroutine energy_calculation
+!f2py real*8 :: energy
+ real(mykind) :: energy 
+
  integer :: iflow
  integer :: idiski, ndim
  integer :: istore, istore_restart 

--- a/src/mod_streams.F90
+++ b/src/mod_streams.F90
@@ -81,6 +81,12 @@ module mod_streams
  ! boundary condition integer (see bc.f90) to indicate that the bottom boundary
  ! of the SBLI case should be blowing
  integer, parameter :: blowing_sbli_boundary_condition = 11
+
+
+ ! dissipation_rate is calculated in dissipation.F90, subroutine dissipation_calculation
+!f2py real*8 :: dissipation_rate
+ real(mykind) :: dissipation_rate
+
  integer :: iflow
  integer :: idiski, ndim
  integer :: istore, istore_restart 

--- a/src/mod_streams.F90
+++ b/src/mod_streams.F90
@@ -73,6 +73,34 @@ module mod_streams
  !f2py real*8, dimension(:), allocatable :: tauw_x
  real(mykind), dimension(:), allocatable :: tauw_x
 
+ ! this is a 2D array in (X,Z) that determines what the y velocity should be at each coordinate
+ ! it is of dimensions (nx_slot, nz_slot), and nx_slot,nz_slot are set on a per-mpi basis
+ ! meaning that they may be different depending on the location
+ !f2py real*8, dimension(:, :), allocatable :: blowing_bc_slot_velocity
+ real(mykind), dimension(:, :), allocatable :: blowing_bc_slot_velocity
+
+ !f2py intent(hide) :: blowing_bc_slot_velocity_gpu
+ real(mykind), dimension(:, :), allocatable :: blowing_bc_slot_velocity_gpu
+
+ ! nx_slot is the number of points in the x direction that will have the blowing boundary
+ ! condition
+ ! nz_slot is the number of points in the z direction that will have the blowing boundary
+ ! condition
+ ! x_start_slot is the location in x point at which the slot should start. If x_start_slot
+ ! is -1 then the current MPI process should NOT worry about writing any blowing slot information
+ ! since the slot has been placed in another MPI process domain
+
+ !f2py integer :: nx_slot, nz_slot, x_start_slot
+ integer :: nx_slot, nz_slot, x_start_slot
+
+ ! same as above (except they are positions instead of lengths), 
+ ! but not set on an MPI basis. Instead, these parameters are set 
+ ! from the config file and the correct `nx_slot`, `ny_slot`, `x_start_slot` are derived from
+ ! these parameters
+
+ !f2py integer :: slot_start_x_global, slot_end_x_global
+ integer :: slot_start_x_global, slot_end_x_global
+
  ! the number of solver steps between outputting probe information / span average information
  integer :: save_probe_steps, save_span_average_steps
  ! override the default boundary condition on the bottom surface for SBLI conditions
@@ -230,6 +258,8 @@ module mod_streams
  attributes(device) :: fhat_trans_gpu, fl_trans_gpu
  attributes(device) :: temperature_trans_gpu
  attributes(device) :: wv_gpu, wv_trans_gpu
+
+ attributes(device) :: blowing_bc_slot_velocity_gpu
 !
  ! TODO: this might be problematic
  !f2py intent(hide) :: local_comm, mydev

--- a/src/mod_streams.F90
+++ b/src/mod_streams.F90
@@ -90,7 +90,7 @@ module mod_streams
  ! is -1 then the current MPI process should NOT worry about writing any blowing slot information
  ! since the slot has been placed in another MPI process domain
 
- !f2py integer :: nx_slot, nz_slot, x_start_slot
+!f2py integer :: nx_slot, nz_slot, x_start_slot
  integer :: nx_slot, nz_slot, x_start_slot
 
  ! same as above (except they are positions instead of lengths), 

--- a/src/mod_streams.F90
+++ b/src/mod_streams.F90
@@ -87,6 +87,16 @@ module mod_streams
 !f2py real*8 :: dissipation_rate
  real(mykind) :: dissipation_rate
 
+ ! stencil for computing finite differences on the irregular y mesh
+!f2py real*8, dimension(:, :), allocatable :: fdm_y_stencil
+ real(mykind), dimension(:, :), allocatable :: fdm_y_stencil
+ real(mykind), dimension(:, :), allocatable :: fdm_y_stencil_gpu
+ ! the array we can re-use for calculating a 4th order accurate approximation for the first derivative
+ ! according to 
+ ! Generation of Finite Difference Formulas on Arbitrarily Spaced Grids (Fornberg, 1988)
+ real(mykind), dimension(:, :, :), allocatable :: fdm_individual_stencil
+ real(mykind), dimension(:), allocatable :: fdm_grid_points
+
  ! energy is calculated in dissipation.F90, subroutine energy_calculation
 !f2py real*8 :: energy
  real(mykind) :: energy 
@@ -241,6 +251,8 @@ module mod_streams
  attributes(device) :: fhat_trans_gpu, fl_trans_gpu
  attributes(device) :: temperature_trans_gpu
  attributes(device) :: wv_gpu, wv_trans_gpu
+
+ attributes(device) :: fdm_y_stencil_gpu
 !
  ! TODO: this might be problematic
  !f2py intent(hide) :: local_comm, mydev

--- a/src/readinp.F90
+++ b/src/readinp.F90
@@ -54,7 +54,9 @@ subroutine readinp
  read (12,*) save_probe_steps, save_span_average_steps
  read (12,*)
  read (12,*)
- read (12,*) force_sbli_blowing_bc
+ read (12,*) force_sbli_blowing_bc, slot_start_x_global, slot_end_x_global
+
+ write(*,*) "slot bounds", slot_start_x_global, slot_end_x_global
 
  close(12)
 !

--- a/src/readinp.F90
+++ b/src/readinp.F90
@@ -90,9 +90,19 @@ subroutine readinp
  case (1) ! BL
   ibc(1) = ibc_inflow
   ibc(2) = 4 ! Extrapolation + non reflecting treatment
-  ibc(3) = 8 ! Wall + reflecting treatment
+  !ibc(3) = 8 
   ibc(4) = 4
   ibcnr(1) = 1
+
+  if (force_sbli_blowing_bc == 1) then
+      ! use blowing boundary condition
+      ibc(3) = blowing_sbli_boundary_condition
+  else
+      ! use default solver BC
+      ! Wall + reflecting treatment
+      ibc(3) = 8
+  endif
+
  case (2) ! SBLI
   ibc(1) = ibc_inflow
   ibc(2) = 4

--- a/src/setup.F90
+++ b/src/setup.F90
@@ -4,6 +4,8 @@ subroutine setup
 !
  use mod_streams
  implicit none
+
+ ! find out the dimensions of the blowing slot
 !
 !===================================================
  if (masterproc) write(error_unit,*) 'Allocation of variables'
@@ -11,6 +13,12 @@ subroutine setup
 !===================================================
  if (masterproc) write(error_unit,*) 'Reading input'
  call readinp()
+
+! separate allocations after the input files have been read so that 
+! the correct boundary conditions may be established
+ call local_slot_locations()
+ call allocate_blowing_bcs()
+
 !===================================================
  if (idiski==0) then
   if (masterproc) write(*,*) 'Generating mesh'

--- a/src/setup.F90
+++ b/src/setup.F90
@@ -30,6 +30,7 @@ subroutine setup
  if (masterproc) write(*,*) 'Initialize field'
  call init()
  call checkdt()
+ call generate_full_fdm_stencil()
 !===================================================
 !
 end subroutine setup


### PR DESCRIPTION
This implements a basic blowing boundary condition for a given start and stop location (grid points) in the config file. The blowing slot amplitude can only be configured through python currently.

Not all MPI nodes in python will have an array allocated (since its not possible to allocate a zero-sized array). MPI nodes in which the slot exists will have an array allocated at `streams.mod_streams.blowing_bc_slot_velocity`.

Configuration of the slot and input files is done from `streams-utils` configuration generator.