### PR TITLE
Export mesh data to HDF5

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -60,6 +60,7 @@ streams.wrap_init_solver()
 flowfields = io_utils.IoFile("/distribute_save/flowfields.h5")
 span_averages = io_utils.IoFile("/distribute_save/span_averages.h5")
 trajectories = io_utils.IoFile("/distribute_save/trajectories.h5")
+mesh_h5 = io_utils.IoFile("/distribute_save/mesh.h5")
 
 grid_shape = [config.grid.nx, config.grid.ny, config.grid.nz]
 span_average_shape = [config.grid.nx, config.grid.ny]
@@ -76,10 +77,23 @@ flowfield_time_dset = io_utils.Scalar1D(flowfields, [1], flowfield_writes, "time
 numwrites = int(math.ceil(config.temporal.num_iter / config.temporal.span_average_io_steps))
 span_average_dset = io_utils.VectorFieldXY2D(span_averages, [5, *span_average_shape], numwrites, "span_average", rank)
 shear_stress_dset = io_utils.ScalarFieldX1D(span_averages, [config.grid.nx], numwrites, "shear_stress", rank)
-span_average_time_dset = io_utils.Scalar1D(span_averages, [1], numwrites, "time", rank)
+span_average_time_dset = io_utils.Scalar0D(span_averages, [1], numwrites, "time", rank)
 
 # trajectories files
-dt_dset = io_utils.Scalar1D(trajectories, [1], config.temporal.num_iter, "dt", rank)
+dt_dset = io_utils.Scalar0D(trajectories, [1], config.temporal.num_iter, "dt", rank)
+
+# mesh datasets
+x_mesh_dset = io_utils.Scalar1DX(mesh_h5, [config.grid.nx], 1, "x_grid", rank)
+y_mesh_dset = io_utils.Scalar1D(mesh_h5, [config.grid.ny], 1, "y_grid", rank)
+z_mesh_dset = io_utils.Scalar1D(mesh_h5, [config.grid.nz], 1, "z_grid", rank)
+
+x_mesh = streams.mod_streams.x[config.x_start():config.x_end()]
+y_mesh = streams.mod_streams.y[config.y_start():config.y_end()]
+z_mesh = streams.mod_streams.z[config.z_start():config.z_end()]
+
+x_mesh_dset.write_array(x_mesh)
+y_mesh_dset.write_array(y_mesh)
+z_mesh_dset.write_array(z_mesh)
 
 #
 # Main solver loop, we start time stepping until we are done

--- a/src/mod_streams.F90
+++ b/src/mod_streams.F90
@@ -126,6 +126,7 @@ module mod_streams
 ! Coordinates and metric related quantities 
  integer :: jbgrid ! Parameter for grid stretching
  real(mykind) :: rlx,rly,rlz,rlywr,dyp_target
+!f2py real*8, dimension(:), allocatable :: x, y, z
  real(mykind), dimension(:), allocatable :: x,y,z,yn
  real(mykind), dimension(:), allocatable :: x_gpu,y_gpu,z_gpu,yn_gpu
  real(mykind), dimension(:), allocatable :: xg,yg,zg


### PR DESCRIPTION
This PR adds a `mesh.h5` file to the output that has the grid points of the x, y, and z meshes.

Running a simulation with `--x-divisions 600` `--y-divisions 208`  `--z-divisions 150`, along with `--x-length 27`  `--y-length 6`, `--z-length 3.8` we dump an HDF5 file.

using `h5dump` we view the results. Note that for some reason, streams places `z=3.8` on a ghost node, and it is not included in the output of the mesh. However, we still have 150 points in the z direction, and the first point it `z=0` so this seems to be a streams issue.

I also added some extra IO exporters for vectors, and adjusted the naming and comments on another IO exporter for clarity. 

```
HDF5 "output/distribute_save/mesh.h5" {
GROUP "/" {
   DATASET "x_grid" {
      DATATYPE  H5T_IEEE_F32LE
      DATASPACE  SIMPLE { ( 1, 600 ) / ( 1, 600 ) }
      DATA {
      (0,0): 0, 0.0450751, 0.0901503, 0.135225, 0.180301, 0.225376, 0.270451,
      (0,7): 0.315526, 0.360601, 0.405676, 0.450751, 0.495826, 0.540901,
      (0,13): 0.585977, 0.631052, 0.676127, 0.721202, 0.766277, 0.811352,
      (0,19): 0.856427, 0.901502, 0.946578, 0.991653, 1.03673, 1.0818,
      (0,25): 1.12688, 1.17195, 1.21703, 1.2621, 1.30718, 1.35225, 1.39733,
      (0,32): 1.4424, 1.48748, 1.53255, 1.57763, 1.6227, 1.66778, 1.71285,
      (0,39): 1.75793, 1.803, 1.84808, 1.89316, 1.93823, 1.98331, 2.02838,
      (0,46): 2.07346, 2.11853, 2.16361, 2.20868, 2.25376, 2.29883, 2.34391,
      (0,53): 2.38898, 2.43406, 2.47913, 2.52421, 2.56928, 2.61436, 2.65943,
      (0,60): 2.70451, 2.74958, 2.79466, 2.83973, 2.88481, 2.92988, 2.97496,
      (0,67): 3.02003, 3.06511, 3.11018, 3.15526, 3.20033, 3.24541, 3.29048,
      (0,74): 3.33556, 3.38063, 3.42571, 3.47078, 3.51586, 3.56093, 3.60601,
      (0,81): 3.65109, 3.69616, 3.74124, 3.78631, 3.83139, 3.87646, 3.92154,
      (0,88): 3.96661, 4.01169, 4.05676, 4.10184, 4.14691, 4.19199, 4.23706,
      (0,95): 4.28214, 4.32721, 4.37229, 4.41736, 4.46244, 4.50751, 4.55259,
      (0,102): 4.59766, 4.64274, 4.68781, 4.73289, 4.77796, 4.82304, 4.86811,
      (0,109): 4.91319, 4.95826, 5.00334, 5.04841, 5.09349, 5.13856, 5.18364,
      (0,116): 5.22871, 5.27379, 5.31886, 5.36394, 5.40902, 5.45409, 5.49917,
      (0,123): 5.54424, 5.58932, 5.63439, 5.67947, 5.72454, 5.76962, 5.81469,
      (0,130): 5.85977, 5.90484, 5.94992, 5.99499, 6.04007, 6.08514, 6.13022,
      (0,137): 6.17529, 6.22037, 6.26544, 6.31052, 6.35559, 6.40067, 6.44574,
      (0,144): 6.49082, 6.53589, 6.58097, 6.62604, 6.67112, 6.71619, 6.76127,
      (0,151): 6.80634, 6.85142, 6.89649, 6.94157, 6.98664, 7.03172, 7.07679,
      (0,158): 7.12187, 7.16694, 7.21202, 7.2571, 7.30217, 7.34725, 7.39232,
      (0,165): 7.4374, 7.48247, 7.52755, 7.57262, 7.6177, 7.66277, 7.70785,
      (0,172): 7.75292, 7.798, 7.84307, 7.88815, 7.93322, 7.9783, 8.02337,
      (0,179): 8.06845, 8.11352, 8.1586, 8.20367, 8.24875, 8.29382, 8.3389,
      (0,186): 8.38397, 8.42905, 8.47412, 8.5192, 8.56427, 8.60935, 8.65442,
      (0,193): 8.6995, 8.74457, 8.78965, 8.83472, 8.8798, 8.92488, 8.96995,
      (0,200): 9.01503, 9.0601, 9.10518, 9.15025, 9.19533, 9.2404, 9.28548,
      (0,207): 9.33055, 9.37563, 9.4207, 9.46578, 9.51085, 9.55593, 9.601,
      (0,214): 9.64608, 9.69115, 9.73623, 9.7813, 9.82638, 9.87145, 9.91653,
      (0,221): 9.9616, 10.0067, 10.0518, 10.0968, 10.1419, 10.187, 10.2321,
      (0,228): 10.2771, 10.3222, 10.3673, 10.4124, 10.4574, 10.5025, 10.5476,
      (0,235): 10.5927, 10.6377, 10.6828, 10.7279, 10.773, 10.818, 10.8631,
      (0,242): 10.9082, 10.9533, 10.9983, 11.0434, 11.0885, 11.1336, 11.1786,
      (0,249): 11.2237, 11.2688, 11.3139, 11.3589, 11.404, 11.4491, 11.4942,
      (0,256): 11.5392, 11.5843, 11.6294, 11.6745, 11.7195, 11.7646, 11.8097,
      (0,263): 11.8548, 11.8998, 11.9449, 11.99, 12.0351, 12.0801, 12.1252,
      (0,270): 12.1703, 12.2154, 12.2604, 12.3055, 12.3506, 12.3957, 12.4407,
      (0,277): 12.4858, 12.5309, 12.576, 12.621, 12.6661, 12.7112, 12.7563,
      (0,284): 12.8013, 12.8464, 12.8915, 12.9366, 12.9816, 13.0267, 13.0718,
      (0,291): 13.1169, 13.1619, 13.207, 13.2521, 13.2972, 13.3422, 13.3873,
      (0,298): 13.4324, 13.4775, 13.5225, 13.5676, 13.6127, 13.6578, 13.7028,
      (0,305): 13.7479, 13.793, 13.8381, 13.8831, 13.9282, 13.9733, 14.0184,
      (0,312): 14.0634, 14.1085, 14.1536, 14.1987, 14.2437, 14.2888, 14.3339,
      (0,319): 14.379, 14.424, 14.4691, 14.5142, 14.5593, 14.6043, 14.6494,
      (0,326): 14.6945, 14.7396, 14.7846, 14.8297, 14.8748, 14.9199, 14.9649,
      (0,333): 15.01, 15.0551, 15.1002, 15.1452, 15.1903, 15.2354, 15.2805,
      (0,340): 15.3255, 15.3706, 15.4157, 15.4608, 15.5058, 15.5509, 15.596,
      (0,347): 15.6411, 15.6861, 15.7312, 15.7763, 15.8214, 15.8664, 15.9115,
      (0,354): 15.9566, 16.0017, 16.0467, 16.0918, 16.1369, 16.182, 16.227,
      (0,361): 16.2721, 16.3172, 16.3623, 16.4073, 16.4524, 16.4975, 16.5426,
      (0,368): 16.5876, 16.6327, 16.6778, 16.7229, 16.7679, 16.813, 16.8581,
      (0,375): 16.9032, 16.9482, 16.9933, 17.0384, 17.0835, 17.1285, 17.1736,
      (0,382): 17.2187, 17.2638, 17.3088, 17.3539, 17.399, 17.4441, 17.4891,
      (0,389): 17.5342, 17.5793, 17.6244, 17.6694, 17.7145, 17.7596, 17.8047,
      (0,396): 17.8498, 17.8948, 17.9399, 17.985, 18.0301, 18.0751, 18.1202,
      (0,403): 18.1653, 18.2104, 18.2554, 18.3005, 18.3456, 18.3907, 18.4357,
      (0,410): 18.4808, 18.5259, 18.571, 18.616, 18.6611, 18.7062, 18.7513,
      (0,417): 18.7963, 18.8414, 18.8865, 18.9316, 18.9766, 19.0217, 19.0668,
      (0,424): 19.1119, 19.1569, 19.202, 19.2471, 19.2922, 19.3372, 19.3823,
      (0,431): 19.4274, 19.4725, 19.5175, 19.5626, 19.6077, 19.6528, 19.6978,
      (0,438): 19.7429, 19.788, 19.8331, 19.8781, 19.9232, 19.9683, 20.0134,
      (0,445): 20.0584, 20.1035, 20.1486, 20.1937, 20.2387, 20.2838, 20.3289,
      (0,452): 20.374, 20.419, 20.4641, 20.5092, 20.5543, 20.5993, 20.6444,
      (0,459): 20.6895, 20.7346, 20.7796, 20.8247, 20.8698, 20.9149, 20.9599,
      (0,466): 21.005, 21.0501, 21.0952, 21.1402, 21.1853, 21.2304, 21.2755,
      (0,473): 21.3205, 21.3656, 21.4107, 21.4558, 21.5008, 21.5459, 21.591,
      (0,480): 21.6361, 21.6811, 21.7262, 21.7713, 21.8164, 21.8614, 21.9065,
      (0,487): 21.9516, 21.9967, 22.0417, 22.0868, 22.1319, 22.177, 22.222,
      (0,494): 22.2671, 22.3122, 22.3573, 22.4023, 22.4474, 22.4925, 22.5376,
      (0,501): 22.5826, 22.6277, 22.6728, 22.7179, 22.7629, 22.808, 22.8531,
      (0,508): 22.8982, 22.9432, 22.9883, 23.0334, 23.0785, 23.1235, 23.1686,
      (0,515): 23.2137, 23.2588, 23.3038, 23.3489, 23.394, 23.4391, 23.4841,
      (0,522): 23.5292, 23.5743, 23.6194, 23.6644, 23.7095, 23.7546, 23.7997,
      (0,529): 23.8447, 23.8898, 23.9349, 23.98, 24.025, 24.0701, 24.1152,
      (0,536): 24.1603, 24.2053, 24.2504, 24.2955, 24.3406, 24.3856, 24.4307,
      (0,543): 24.4758, 24.5209, 24.5659, 24.611, 24.6561, 24.7012, 24.7462,
      (0,550): 24.7913, 24.8364, 24.8815, 24.9265, 24.9716, 25.0167, 25.0618,
      (0,557): 25.1068, 25.1519, 25.197, 25.2421, 25.2871, 25.3322, 25.3773,
      (0,564): 25.4224, 25.4674, 25.5125, 25.5576, 25.6027, 25.6477, 25.6928,
      (0,571): 25.7379, 25.783, 25.828, 25.8731, 25.9182, 25.9633, 26.0083,
      (0,578): 26.0534, 26.0985, 26.1436, 26.1886, 26.2337, 26.2788, 26.3239,
      (0,585): 26.3689, 26.414, 26.4591, 26.5042, 26.5492, 26.5943, 26.6394,
      (0,592): 26.6845, 26.7295, 26.7746, 26.8197, 26.8648, 26.9098, 26.9549,
      (0,599): 27
      }
   }
   DATASET "y_grid" {
      DATATYPE  H5T_IEEE_F32LE
      DATASPACE  SIMPLE { ( 1, 208 ) / ( 1, 208 ) }
      DATA {
      (0,0): 0, 0.00280226, 0.00560588, 0.00841222, 0.0112226, 0.0140385,
      (0,6): 0.0168611, 0.0196919, 0.0225323, 0.0253836, 0.0282472,
      (0,11): 0.0311244, 0.0340168, 0.0369256, 0.0398523, 0.0427983,
      (0,16): 0.0457651, 0.048754, 0.0517666, 0.0548042, 0.0578684,
      (0,21): 0.0609607, 0.0640824, 0.0672352, 0.0704206, 0.0736402,
      (0,26): 0.0768953, 0.0801878, 0.0835191, 0.0868909, 0.0903047,
      (0,31): 0.0937624, 0.0972654, 0.100816, 0.104415, 0.108064, 0.111766,
      (0,37): 0.115522, 0.119334, 0.123204, 0.127134, 0.131125, 0.13518,
      (0,43): 0.1393, 0.143488, 0.147745, 0.152074, 0.156476, 0.160955,
      (0,49): 0.165511, 0.170148, 0.174867, 0.17967, 0.184561, 0.189541,
      (0,55): 0.194613, 0.199779, 0.205042, 0.210405, 0.215869, 0.221438,
      (0,61): 0.227114, 0.232901, 0.2388, 0.244815, 0.250948, 0.257203,
      (0,67): 0.263583, 0.27009, 0.276729, 0.283501, 0.29041, 0.297461,
      (0,73): 0.304655, 0.311998, 0.319491, 0.327139, 0.334945, 0.342914,
      (0,79): 0.351049, 0.359354, 0.367834, 0.376491, 0.385331, 0.394357,
      (0,85): 0.403575, 0.412988, 0.422602, 0.43242, 0.442447, 0.452689,
      (0,91): 0.46315, 0.473836, 0.484751, 0.495901, 0.507291, 0.518928,
      (0,97): 0.530815, 0.54296, 0.555368, 0.568045, 0.580997, 0.594231,
      (0,103): 0.607752, 0.621568, 0.635685, 0.650111, 0.664851, 0.679913,
      (0,109): 0.695305, 0.711033, 0.727107, 0.743532, 0.760318, 0.777472,
      (0,115): 0.795002, 0.812918, 0.831228, 0.849941, 0.869065, 0.888611,
      (0,121): 0.908587, 0.929003, 0.949869, 0.971196, 0.992993, 1.01527,
      (0,127): 1.03804, 1.06131, 1.0851, 1.10941, 1.13427, 1.15967, 1.18563,
      (0,134): 1.21216, 1.23929, 1.26701, 1.29535, 1.32432, 1.35392, 1.38419,
      (0,141): 1.41512, 1.44674, 1.47906, 1.5121, 1.54587, 1.58039, 1.61567,
      (0,148): 1.65174, 1.68861, 1.72629, 1.76482, 1.80419, 1.84444, 1.88559,
      (0,155): 1.92765, 1.97064, 2.01459, 2.05951, 2.10543, 2.15238, 2.20036,
      (0,162): 2.24941, 2.29955, 2.35081, 2.4032, 2.45676, 2.51151, 2.56747,
      (0,169): 2.62468, 2.68316, 2.74294, 2.80405, 2.86652, 2.93038, 2.99566,
      (0,176): 3.06238, 3.1306, 3.20033, 3.27161, 3.34447, 3.41896, 3.4951,
      (0,183): 3.57293, 3.6525, 3.73384, 3.81698, 3.90198, 3.98886, 4.07768,
      (0,190): 4.16847, 4.26129, 4.35616, 4.45315, 4.5523, 4.65365, 4.75725,
      (0,197): 4.86315, 4.97133, 5.0817, 5.19401, 5.30782, 5.42258, 5.53786,
      (0,204): 5.65333, 5.76888, 5.88444, 6
      }
   }
   DATASET "z_grid" {
      DATATYPE  H5T_IEEE_F32LE
      DATASPACE  SIMPLE { ( 1, 150 ) / ( 1, 150 ) }
      DATA {
      (0,0): 0, 0.0253333, 0.0506667, 0.076, 0.101333, 0.126667, 0.152,
      (0,7): 0.177333, 0.202667, 0.228, 0.253333, 0.278667, 0.304, 0.329333,
      (0,14): 0.354667, 0.38, 0.405333, 0.430667, 0.456, 0.481333, 0.506667,
      (0,21): 0.532, 0.557333, 0.582667, 0.608, 0.633333, 0.658667, 0.684,
      (0,28): 0.709333, 0.734667, 0.76, 0.785333, 0.810667, 0.836, 0.861333,
      (0,35): 0.886667, 0.912, 0.937333, 0.962667, 0.988, 1.01333, 1.03867,
      (0,42): 1.064, 1.08933, 1.11467, 1.14, 1.16533, 1.19067, 1.216,
      (0,49): 1.24133, 1.26667, 1.292, 1.31733, 1.34267, 1.368, 1.39333,
      (0,56): 1.41867, 1.444, 1.46933, 1.49467, 1.52, 1.54533, 1.57067,
      (0,63): 1.596, 1.62133, 1.64667, 1.672, 1.69733, 1.72267, 1.748,
      (0,70): 1.77333, 1.79867, 1.824, 1.84933, 1.87467, 1.9, 1.92533,
      (0,77): 1.95067, 1.976, 2.00133, 2.02667, 2.052, 2.07733, 2.10267,
      (0,84): 2.128, 2.15333, 2.17867, 2.204, 2.22933, 2.25467, 2.28,
      (0,91): 2.30533, 2.33067, 2.356, 2.38133, 2.40667, 2.432, 2.45733,
      (0,98): 2.48267, 2.508, 2.53333, 2.55867, 2.584, 2.60933, 2.63467,
      (0,105): 2.66, 2.68533, 2.71067, 2.736, 2.76133, 2.78667, 2.812,
      (0,112): 2.83733, 2.86267, 2.888, 2.91333, 2.93867, 2.964, 2.98933,
      (0,119): 3.01467, 3.04, 3.06533, 3.09067, 3.116, 3.14133, 3.16667,
      (0,126): 3.192, 3.21733, 3.24267, 3.268, 3.29333, 3.31867, 3.344,
      (0,133): 3.36933, 3.39467, 3.42, 3.44533, 3.47067, 3.496, 3.52133,
      (0,140): 3.54667, 3.572, 3.59733, 3.62267, 3.648, 3.67333, 3.69867,
      (0,147): 3.724, 3.74933, 3.77467
      }
   }
}
}
```